### PR TITLE
Added Browsersync for auto-reload on change and css injection.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "server.js",
   "scripts": {
+    "browser-sync": "browser-sync start --proxy localhost:3000 --port 3001 --files ./browser/public",
     "dev-mac": "npm install && npm run sass && npm run watch-mac",
     "dev-windows": "npm install && npm run sass && npm run watch-windows",
     "sass": "node-sass --recursive browser/src/sass --output browser/public/css",
@@ -11,8 +12,8 @@
     "start": "node server.js",
     "start-dev": "nodemon server.js --ignore ./browser/src --ignore ./browser/public",
     "test": "NODE_ENV=test jest --config ./server/jest.config.js",
-    "watch-mac": "npm run sass-watch & npm run webpack-watch & npm run start-dev",
-    "watch-windows": "start /B npm run sass-watch & start /B npm run webpack-watch & start /B npm run start-dev",
+    "watch-mac": "npm run sass-watch & npm run webpack-watch & npm run start-dev & browser-sync",
+    "watch-windows": "start /B npm run sass-watch & start /B npm run webpack-watch & start /B npm run start-dev & start /B npm run browser-sync",
     "webpack": "webpack",
     "webpack-watch": "webpack -w"
   },
@@ -50,12 +51,13 @@
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",
-    "@babel/polyfill": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.2.1",
+    "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.4",
+    "browser-sync": "^2.26.3",
     "jest": "^23.6.0",
     "node-sass": "^4.10.0",
     "nodemon": "^1.18.6",


### PR DESCRIPTION
Hey everyone. I added  a BrowserSync script to the npm script workflow. It will auto reload on changes to everything except CSS. For CSS, it will inject changes without reload. I could only test it on a Windows machine , so I'd appreciate it if someone could give it a go on Mac. You don't have to do anything special, just `npm run dev-mac`. Thanks!