### PR TITLE
Added babel-eslint as estlint parser and turned off linebreak-sytle r…

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,7 @@
 {
-    "extends": "airbnb"
+  "extends": "airbnb",
+  "rules": {
+    "linebreak-style": "off"
+  },
+  "parser": "babel-eslint"
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
     "babel-core": "^7.0.0-bridge.0",
+    "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.4",
     "eslint": "^5.13.0",
     "eslint-config-airbnb": "^17.1.0",


### PR DESCRIPTION
…ules.

- This will allow ESLint to recognize es7 features.
- Windows users don't have to worry about line-ending errors from ESLint while developing. Git will take care of converting CRLF to LF on commit's automatically.